### PR TITLE
Add profile management routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Admin\ReportController as AdminReportController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\PublicReportController;
+use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
 // Redirect root to public report page
@@ -24,6 +25,12 @@ Route::prefix('report')->name('public.report.')->group(function () {
 
 // Authentication routes
 require __DIR__.'/auth.php';
+
+Route::middleware('auth')->group(function () {
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
 
 // Admin Routes (Protected)
 Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(function () {


### PR DESCRIPTION
## Summary
- add authentication-protected routes for user profile editing, updating, and deletion

## Testing
- `composer install` (fails: curl error 56, CONNECT tunnel failed)
- `php artisan route:list` (fails: Failed opening required 'vendor/autoload.php')

------
https://chatgpt.com/codex/tasks/task_e_689d58045238832f9295305ee7a67619