### PR TITLE
Add missing dashboard route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,11 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+// General Dashboard Route
+Route::get('/dashboard', function () {
+    return view('dashboard');
+})->middleware(['auth', 'verified'])->name('dashboard');
+
 // Admin Routes (Protected)
 Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(function () {
     


### PR DESCRIPTION
## Summary
- add general `/dashboard` route for authenticated users

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d5d38f230832f979e58cc629282f8