### PR TITLE
Register authorization gates for admin features

### DIFF
--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -21,9 +21,12 @@ class RoleMiddleware
         }
 
         $user = Auth::user();
-        
-        // Check if user has any of the required roles
-        if (!in_array($user->role, $roles)) {
+
+        $userRole = strtolower($user->role);
+        $roles = array_map('strtolower', $roles);
+
+        // Check if user has any of the required roles (case-insensitive)
+        if (!in_array($userRole, $roles)) {
             abort(403, 'Unauthorized action.');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,32 +68,34 @@ class User extends Authenticatable
     // Role checking methods
     public function isAdmin(): bool
     {
-        return $this->role === 'admin';
+        return strtolower($this->role) === 'admin';
     }
 
     public function isModerator(): bool
     {
-        return $this->role === 'moderator';
+        return strtolower($this->role) === 'moderator';
     }
 
     public function isInvestigator(): bool
     {
-        return $this->role === 'investigator';
+        return strtolower($this->role) === 'investigator';
     }
 
     public function canManageReports(): bool
     {
-        return in_array($this->role, ['admin', 'moderator', 'investigator']);
+        $role = strtolower($this->role);
+        return in_array($role, ['admin', 'moderator', 'investigator']);
     }
 
     public function canManageUsers(): bool
     {
-        return $this->role === 'admin';
+        return strtolower($this->role) === 'admin';
     }
 
     public function canManageCategories(): bool
     {
-        return in_array($this->role, ['admin', 'moderator']);
+        $role = strtolower($this->role);
+        return in_array($role, ['admin', 'moderator']);
     }
 
     // Scopes

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Policies\ReportPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -26,5 +27,10 @@ class AuthServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerPolicies();
+
+        Gate::define('manageCategories', [UserPolicy::class, 'manageCategories']);
+        Gate::define('manageUsers', [UserPolicy::class, 'manageUsers']);
+        Gate::define('viewAnalytics', [UserPolicy::class, 'viewAnalytics']);
+        Gate::define('exportData', [UserPolicy::class, 'exportData']);
     }
 }

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -1,0 +1,46 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Category') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="POST" action="{{ route('admin.categories.store') }}" class="space-y-6">
+                        @csrf
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required autofocus />
+                            <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="description" :value="__('Description')" />
+                            <textarea id="description" name="description" class="mt-1 block w-full border-gray-300 rounded-md" rows="4"></textarea>
+                            <x-input-error class="mt-2" :messages="$errors->get('description')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="color" :value="__('Color')" />
+                            <x-text-input id="color" name="color" type="color" class="mt-1 h-10 w-20 p-0 border-0" />
+                            <x-input-error class="mt-2" :messages="$errors->get('color')" />
+                        </div>
+
+                        <div class="flex items-center">
+                            <input id="is_active" name="is_active" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" checked>
+                            <label for="is_active" class="ml-2 block text-sm text-gray-900">{{ __('Active') }}</label>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -1,0 +1,47 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Category') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="POST" action="{{ route('admin.categories.update', $category) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $category->name)" required autofocus />
+                            <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="description" :value="__('Description')" />
+                            <textarea id="description" name="description" class="mt-1 block w-full border-gray-300 rounded-md" rows="4">{{ old('description', $category->description) }}</textarea>
+                            <x-input-error class="mt-2" :messages="$errors->get('description')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="color" :value="__('Color')" />
+                            <x-text-input id="color" name="color" type="color" class="mt-1 h-10 w-20 p-0 border-0" :value="old('color', $category->color)" />
+                            <x-input-error class="mt-2" :messages="$errors->get('color')" />
+                        </div>
+
+                        <div class="flex items-center">
+                            <input id="is_active" name="is_active" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" {{ old('is_active', $category->is_active) ? 'checked' : '' }}>
+                            <label for="is_active" class="ml-2 block text-sm text-gray-900">{{ __('Active') }}</label>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/categories/show.blade.php
+++ b/resources/views/admin/categories/show.blade.php
@@ -1,0 +1,44 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $category->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 space-y-4">
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Description') }}</h3>
+                        <p class="mt-1 text-gray-900">{{ $category->description ?? __('No description') }}</p>
+                    </div>
+                    <div class="flex items-center space-x-2">
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Color') }}:</h3>
+                        <div class="w-6 h-6 rounded border" style="background-color: {{ $category->color }}"></div>
+                        <span class="text-sm font-mono">{{ $category->color }}</span>
+                    </div>
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Status') }}</h3>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $category->is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                            {{ $category->is_active ? __('Active') : __('Inactive') }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            @if($category->reports->count() > 0)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">{{ __('Reports') }}</h3>
+                        <ul class="divide-y divide-gray-200">
+                            @foreach($category->reports as $report)
+                                <li class="py-2">{{ $report->title }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,0 +1,67 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create User') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="POST" action="{{ route('admin.users.store') }}" class="space-y-6">
+                        @csrf
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required autofocus />
+                            <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="email" :value="__('Email')" />
+                            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" required />
+                            <x-input-error class="mt-2" :messages="$errors->get('email')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="password" :value="__('Password')" />
+                            <x-text-input id="password" name="password" type="password" class="mt-1 block w-full" required />
+                            <x-input-error class="mt-2" :messages="$errors->get('password')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+                            <x-text-input id="password_confirmation" name="password_confirmation" type="password" class="mt-1 block w-full" required />
+                        </div>
+
+                        <div>
+                            <x-input-label for="role" :value="__('Role')" />
+                            <select id="role" name="role" class="mt-1 block w-full border-gray-300 rounded-md">
+                                @foreach($roles as $role)
+                                    <option value="{{ $role }}">{{ ucfirst($role) }}</option>
+                                @endforeach
+                            </select>
+                            <x-input-error class="mt-2" :messages="$errors->get('role')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="department" :value="__('Department')" />
+                            <x-text-input id="department" name="department" type="text" class="mt-1 block w-full" />
+                            <x-input-error class="mt-2" :messages="$errors->get('department')" />
+                        </div>
+
+                        <div class="flex items-center">
+                            <input id="is_active" name="is_active" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" checked>
+                            <label for="is_active" class="ml-2 block text-sm text-gray-900">{{ __('Active') }}</label>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,57 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit User') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <form method="POST" action="{{ route('admin.users.update', $user) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)" required autofocus />
+                            <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="email" :value="__('Email')" />
+                            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required />
+                            <x-input-error class="mt-2" :messages="$errors->get('email')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="role" :value="__('Role')" />
+                            <select id="role" name="role" class="mt-1 block w-full border-gray-300 rounded-md">
+                                @foreach($roles as $role)
+                                    <option value="{{ $role }}" {{ old('role', $user->role) === $role ? 'selected' : '' }}>{{ ucfirst($role) }}</option>
+                                @endforeach
+                            </select>
+                            <x-input-error class="mt-2" :messages="$errors->get('role')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="department" :value="__('Department')" />
+                            <x-text-input id="department" name="department" type="text" class="mt-1 block w-full" :value="old('department', $user->department)" />
+                            <x-input-error class="mt-2" :messages="$errors->get('department')" />
+                        </div>
+
+                        <div class="flex items-center">
+                            <input id="is_active" name="is_active" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" {{ old('is_active', $user->is_active) ? 'checked' : '' }}>
+                            <label for="is_active" class="ml-2 block text-sm text-gray-900">{{ __('Active') }}</label>
+                        </div>
+
+                        <div class="flex justify-end">
+                            <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -1,0 +1,60 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $user->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 space-y-4">
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Email') }}</h3>
+                        <p class="mt-1 text-gray-900">{{ $user->email }}</p>
+                    </div>
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Role') }}</h3>
+                        <p class="mt-1 text-gray-900">{{ ucfirst($user->role) }}</p>
+                    </div>
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Department') }}</h3>
+                        <p class="mt-1 text-gray-900">{{ $user->department ?? __('None') }}</p>
+                    </div>
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-500">{{ __('Status') }}</h3>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $user->is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                            {{ $user->is_active ? __('Active') : __('Inactive') }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            @if($user->assignedReports->count() > 0)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">{{ __('Assigned Reports') }}</h3>
+                        <ul class="divide-y divide-gray-200">
+                            @foreach($user->assignedReports as $report)
+                                <li class="py-2">{{ $report->title }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+
+            @if($user->reportComments->count() > 0)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">{{ __('Recent Comments') }}</h3>
+                        <ul class="divide-y divide-gray-200">
+                            @foreach($user->reportComments as $comment)
+                                <li class="py-2">{{ $comment->body }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- register gates for category management, user management, analytics and data export
- add create, edit, and show views for admin category and user management
- normalize role checks so admin and moderator access is case-insensitive

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d604aee60832f9052918f2cc86266